### PR TITLE
Promote KernelCare if not installed.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -50,23 +50,23 @@ sub generate_advice {
 sub _suggest_kernelcare {
     my ($self) = @_;
 
-    my $environment = Cpanel::OSSys::Env::get_envtype();
+    my $environment  = Cpanel::OSSys::Env::get_envtype();
     my $manage2_data = _get_manage2_kernelcare_data();
 
-    if ( not -e q{/usr/bin/kcarectl}
-         and not( $environment eq 'virtuozzo' || $environment eq 'lxc' )
-         and not $manage2_data->{'disabled'} ) {
+    if (    not -e q{/usr/bin/kcarectl}
+        and not( $environment eq 'virtuozzo' || $environment eq 'lxc' )
+        and not $manage2_data->{'disabled'} ) {
 
         my $contact_method = '';
-        my $url_alt_text = 'Upgrade to KernelCare';
-        my $url_to_use = 'https://go.cpanel.net/KernelCare';
+        my $url_alt_text   = 'Upgrade to KernelCare';
+        my $url_to_use     = 'https://go.cpanel.net/KernelCare';
         if ( $manage2_data->{'url'} ne '' ) {
             $url_to_use = $manage2_data->{'url'};
         }
         elsif ( $manage2_data->{'email'} ne '' ) {
-            $url_to_use = 'mailto:' . $manage2_data->{'email'};
+            $url_to_use     = 'mailto:' . $manage2_data->{'email'};
             $contact_method = 'For more information,';
-            $url_alt_text = 'email your provider.';
+            $url_alt_text   = 'email your provider.';
         }
 
         $self->add_info_advice(
@@ -83,8 +83,8 @@ sub _get_manage2_kernelcare_data {
 
     # figure out what manage2 url to use...
     my $manage2 = 'manage2.cpanel.net';
-    if ( -e '/var/cpanel/dev_sandbox') {
-       $manage2 = 'swaaat.manage2.manage.devel.cpanel.net';
+    if ( -e '/var/cpanel/dev_sandbox' ) {
+        $manage2 = 'swaaat.manage2.manage.devel.cpanel.net';
     }
 
     # get our companyid

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -63,10 +63,10 @@ sub _suggest_kernelcare {
         if ( $manage2_data->{'url'} ne '' ) {
             $url_to_use = $manage2_data->{'url'};
         }
-        if ( $manage2_data->{'email'} ne '' ) {
+        elsif ( $manage2_data->{'email'} ne '' ) {
             $url_to_use = 'mailto:' . $manage2_data->{'email'};
             $contact_method = 'For more information,';
-            $url_alt_text = 'email your cPanel partner.';
+            $url_alt_text = 'email your provider.';
         }
 
         $self->add_info_advice(


### PR DESCRIPTION
Case SWAT-22, SWAT-320: Added a check to see if KC is installed, if not
provide an "info" advisory with a link to the KernelCare site for
buying/installing.

The decision whether or not to show the info advisory is based on three
criteria:
* If KC is already installed, don't bother.
* If we're in an environment that *can't* use KC, don't bother.
* If the partner for this server has decreed that "thou shalt not,"
  then don't. If they've listed an alternative path for that--via
  another website or email address, show it, but use that link instead.

I can't take credit for all of this--some of it was Brett's original
info banner implementation.