### PR TITLE
Prevent offering KernelCare on Amazon Cloud

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -39,6 +39,7 @@ use Cpanel::Logger          ();
 use Cpanel::DIp::MainIP     ();
 use Cpanel::NAT             ();
 use Cpanel::HTTP::Client    ();
+use Cpanel::GenSysInfo      ();
 
 our $VERIFY_SSL    = 1;
 our $KC_CP_VERSION = q{11.63};
@@ -68,11 +69,13 @@ sub _suggest_kernelcare {
     my ($self) = @_;
 
     my $environment  = Cpanel::OSSys::Env::get_envtype();
+    my $sysinfo      = Cpanel::GenSysInfo::run();
     my $manage2_data = _get_manage2_kernelcare_data();
     my $rpm          = Cpanel::RPM->new();
 
     if (    not $rpm->has_rpm(q{kernelcare})
         and not( $environment eq 'virtuozzo' || $environment eq 'lxc' )
+        and $sysinfo->{'rpm_dist'} ne 'amazon'
         and not $manage2_data->{'disabled'} ) {
 
         my $contact_method = '';


### PR DESCRIPTION
SWAT-410: We don't want to offer KernelCare on Amazon Cloud
servers. So, block that.